### PR TITLE
Updated Requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 discord
 requests
-dotenv
+python-dotenv


### PR DESCRIPTION
while installing packages from requirements.txt  
installation of **dotenv** was stucked .
I checked out the correct name of the package for dotenv for installation it was : `pip install python-dotenv` 

reference : https://pypi.org/project/python-dotenv/

![image](https://user-images.githubusercontent.com/63723893/136349217-17649cf6-123e-4dd1-b7e8-66f151d1444d.png)
